### PR TITLE
Fix for quotes breaking publish view

### DIFF
--- a/fields/field.reflection.php
+++ b/fields/field.reflection.php
@@ -186,7 +186,7 @@
 				$label->appendChild(
 					Widget::Input(
 						"fields{$prefix}[$element_name]{$postfix}",
-						@$data['value'], 'text', $allow_override
+						@$data['value_formatted'], 'text', $allow_override
 					)
 				);
 				$wrapper->appendChild($label);


### PR DESCRIPTION
Hey Rowan,

just a minor fix for your Reflection Field. It wasn't showing quotes properly in the disabled input field.

Regards, Nils
