### PR TITLE
Fix for quotes breaking publish view

### DIFF
--- a/fields/field.reflection.php
+++ b/fields/field.reflection.php
@@ -186,7 +186,7 @@
 				$label->appendChild(
 					Widget::Input(
 						"fields{$prefix}[$element_name]{$postfix}",
-						@$data['value'], 'text', $allow_override
+						@$data['value_formatted'], 'text', $allow_override
 					)
 				);
 				$wrapper->appendChild($label);


### PR DESCRIPTION
Again, the fix for quotes breaking publish view

If you set up the reflection field to be visible in publish view and any of the referenced fields contains a quote, the field will break and output invalid markup (the `value` attribute of the input field contains quotes and not their HTML-entities counterpart).

Example:

```
  <input name="fields[reflection]" disabled="disabled" type="text" value="Test " Test">
```

This commit fixes it to be

```
  <input name="fields[reflection]" disabled="disabled" type="text" value="Test &quot; Test">
```

Sorry for bombing you with pull-request in the wrong branches. :-)

Nils
