### PR TITLE
Two fixes: for number comparison and other reflection fields values

### DIFF
--- a/fields/field.reflection.php
+++ b/fields/field.reflection.php
@@ -440,11 +440,11 @@
 				";
 			}
 
-			else if (preg_match('/^(?:equal to or )?(?:less than|more than|equal to) \d+(?:\.\d+)?$/i', $data[0])) {
+			else if (preg_match('/^(?:equal to or )?(?:less than|more than|equal to) -?\d+(?:\.\d+)?$/i', $data[0])) {
 
 				$comparisons = array();
 				foreach ($data as $string) {
-					if (preg_match('/^(equal to or )?(less than|more than|equal to) (\d+(?:\.\d+)?)$/i', $string, $matches)) {
+					if (preg_match('/^(equal to or )?(less than|more than|equal to) (-?\d+(?:\.\d+)?)$/i', $string, $matches)) {
 						$number = trim($matches[3]);
 						if (!is_numeric($number) || $number === '') continue;
 						$number = floatval($number);


### PR DESCRIPTION
First fix changes `compile()` function, so it updates current (context) entry data. That allows next reflection fields to use value generated by previous reflection fields of the same entry.

Second fix adds support for numbers that are less than zero, e.g., `-1` or `-0.79`.
