### PR TITLE
Fixed string filter to default to "all" if string is empty.

### DIFF
--- a/fields/field.reflection.php
+++ b/fields/field.reflection.php
@@ -419,6 +419,9 @@
 			
 			else if (preg_match('/^(not-)?((starts|ends)-with|contains):\s*/', $data[0], $matches)) {
 				$data = trim(array_pop(explode(':', $data[0], 2)));
+
+				if ($data == '') return true;
+
 				$negate = ($matches[1] == '' ? '' : 'NOT');
 				$data = $this->cleanValue($data);
 				


### PR DESCRIPTION
Fixed filtering by string ("contains","starts-with",etc...) so it returns true when there is no there is no string to compare to (`data` string is empty). This makes it work like filters in default fields: when filter data is empty, they return all entries.
