### PR TITLE
Add Support for XML Importer

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -57,6 +57,16 @@
 					'callback'	=> 'compileBackendFields'
 				),
 				array(
+					'page'		=> '/xmlimporter/importers/run/',
+					'delegate'	=> 'XMLImporterEntryPostCreate',
+					'callback'	=> 'compileBackendFields'
+				),
+				array(
+					'page'		=> '/xmlimporter/importers/run/',
+					'delegate'	=> 'XMLImporterEntryPostEdit',
+					'callback'	=> 'compileBackendFields'
+				),
+				array(
 					'page'		=> '/frontend/',
 					'delegate'	=> 'EventPostSaveFilter',
 					'callback'	=> 'compileFrontendFields'

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -17,6 +17,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.4.1" date="2015-01-12" min="2.3">
+			- Add XML Importer Support
+		</release>
 		<release version="1.4.0" date="2013-06-22" min="2.3">
 			- Added export modes
 		</release>


### PR DESCRIPTION
Run the Reflection field on Post Create / Edit within the XML Importer by registering for the delegate.

For those seeking to use this functionality it is of utmost importance that in the XML Importer you create a 'dummy' entry such as `concat("","")`to create the initial row in the database. Reflection field only does an update on the field, thus if no entry is found in the DB this will remain blank.