### PR TITLE
Improve data structure

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -17,12 +17,17 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="2.0.0" date="2016-07-13" min="2.3" max="2.7.x">
+			- Added reflection field handle to `param` node
+			- Moved `root` and `workspace` nodes to `param` node to conform with the front-end XML structure
+			- Added XSLT utitlity instructions
+		</release>
 		<release version="1.4.2" date="2016-01-29" min="2.3" max="2.6.x">
 			- Prevent the same field from being registered multiple times
-			- Added XML Importer Instructions
+			- Added XML Importer instructions
 		</release>
 		<release version="1.4.1" date="2015-01-12" min="2.3">
-			- Added XML Importer Support
+			- Added XML Importer support
 			- Added system date to generated entry XML
 		</release>
 		<release version="1.4.0" date="2013-06-22" min="2.3">
@@ -43,20 +48,20 @@
 			- Fixed a sanitisation issue on publish pages.
 			- Made compatible with Symphony 2.2.
 		</release>
-		<release version="1.0.9" date="2010-11-01" min="2.1.*">
+		<release version="1.0.9" date="2010-11-01" min="2.1.x">
 			- Bug with usage of appendFormattedElement fixed by michael-e.
 		</release>
-		<release version="1.0.8" date="2009-12-09" min="2.1.*">
+		<release version="1.0.8" date="2009-12-09" min="2.1.x">
 			- Some bug fixes and code cleanup.
 		</release>
-		<release version="1.0.7" date="2009-08-21" min="2.1.*">
+		<release version="1.0.7" date="2009-08-21" min="2.1.x">
 			- Fixed column sorting issues.
 			- Added more filter modes.
 		</release>
-		<release version="1.0.6" date="2009-04-23" min="2.1.*">
+		<release version="1.0.6" date="2009-04-23" min="2.1.x">
 			- Added a search: filter method to allow you to use boolean type searching.
 		</release>
-		<release version="1.0.6" date="2009-03-30" min="2.1.*">
+		<release version="1.0.6" date="2009-03-30" min="2.1.x">
 			- Fixed a number of possible encoding issues.
 		</release>
 	</releases>

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,56 @@
 # Field: Reflection
 
-Populate this field's value using values from other fields in the same entry. Uses XPath and optionally XSLT.
+This field generates values based on other fields from the same entry.
+Uses XPath and optionally XSLT.
 
-## Installation
+# Usage
 
-1. Upload the `/reflectionfield` folder to your Symphony `/extensions` folder.
+When saving an entry Reflection field creates an internal `data` structure similar to what Symphony provides on the front-end. Besides the field data contextual parameters like the root and workspace paths and the section handle are available as well.
 
-2. Enable it by selecting the "Field: Reflection", choose Enable/Install from the dropdown, then click Apply.
+```xml
+<data>
+	<params>
+		<today>2016-08-02</today>
+		<current-time>12:34</current-time>
+		<this-year>2016</this-year>
+		<this-month>08</this-month>
+		<this-day>02</this-day>
+		<timezone>+02:00</timezone>
+		<website-name>Example Website</website-name>
+		<root>https://example.com</root>
+		<workspace>https://example.com/workspace</workspace>
+		<http-host>example.com</http-host>
+		<upload-limit>5242880</upload-limit>
+		<symphony-version>2.7.0</symphony-version>
+	</params>
+	<reflection-field-handle>
+		<section id="…" handle="…">…</section>
+		<entry id="…">
+			<field-one></field-one>
+            <field-two>
+                <item handle=""></item>
+                <item handle=""></item>
+            </field-two>
+			<system-date>
+				<created iso="" timestamp="" time="" weekday="" offset="">…</created>
+				<modified iso="" timestamp="" time="" weekday="" offset="">…</modified>
+			</system-date>
+		</entry>
+	</reflection-field-handle>
+</data>
+```
 
-4. You can now add the "Reflection" field to your sections.
+**Note:** Version 2.0 changed the `data` structure to conform with the front-end. The `root` and `workspace` nodes moved to the parameter pool. The `entry-id` node was removed as the id was already available on the `entry` node.
 
+## XSLT Utilities
 
-## Usage with XML Importer
+XSL templates are used to manipulate the XML data before building the reflection expression. Any template in `/workspace/utilities` can be attached to the field: it will be provided with the above XML. The extension expects you to return an XML structure again, that is then used inside the expression field.
+
+## Expressions
+
+Expressions are used to build the field's content. You can add static content or markup, dynamic values can be added using curly braces containing and xPath expression to find the needed data. If you don't use an XSLT utility, the xPath expression is evaluated against the above XML. If you transformed the source data using a template, the xPath is evaluated against the returned XML structure you created.
+
+# Usage with XML Importer
 
 Reflection Field assumes that the entry has already saved some data for the said field, and then seeks to update the database directly with the correct reflection generated content.
 In the case of XML Importer this means that you have to include the Reflection field within the import items, otherwise XML Importer will not find any data within your database to update.


### PR DESCRIPTION
I'm not sure, if this is something you'd like to merge, @nitriques, but we needed a lot of reflection fields for a private project and the current way XSL utilities where used was quite confusing. This pull requests **changes the XML structure** provided to utilities, making them conform to the front-end XML. So it will break any existing project using XSL utilities.

The updated XML looks like this:

```xml
<data>
	<params>
		<today>2016-08-02</today>
		<current-time>12:34</current-time>
		<this-year>2016</this-year>
		<this-month>08</this-month>
		<this-day>02</this-day>
		<timezone>+02:00</timezone>
		<website-name>Example Website</website-name>
		<root>https://example.com</root>
		<workspace>https://example.com/workspace</workspace>
		<http-host>example.com</http-host>
		<upload-limit>5242880</upload-limit>
		<symphony-version>2.7.0</symphony-version>
	</params>
	<reflection-field-handle>
		<section id="…" handle="…">…</section>
		<entry id="…">
			<field-one></field-one>
            		<field-two>
     		        	<item handle=""></item>
				<item handle=""></item>
			</field-two>
			<system-date>
				<created iso="" timestamp="" time="" weekday="" offset="">…</created>
				<modified iso="" timestamp="" time="" weekday="" offset="">…</modified>
			</system-date>
		</entry>
	</reflection-field-handle>
</data>
```

It also adds information about how to use XSL utilities and about the XML.
These changes improved our workflow a lot, but it's not backwards compatible.