### PR TITLE
Fix xpath-expressions (#35)

### DIFF
--- a/fields/field.reflection.php
+++ b/fields/field.reflection.php
@@ -385,9 +385,38 @@
             // Find queries:
             preg_match_all('/\{[^\}]+\}/', $expression, $matches);
 
-            // Find replacements:
+            // Get root node name
+            $root_node_name = $xpath->evaluate('name(/*)');
+
+            // Find replacements
+            // including modifications for edge-cases (#35)
             foreach ($matches[0] as $match) {
-                $result = @$xpath->evaluate('string(' . trim($match, '{}') . ')');
+
+                // Add a leading '/' if the expression starts with the root node name
+                // Fixes expressions 1.J and 2.B
+                if (preg_match('#^{'.$root_node_name.'#', $match)) {
+                    $result = @$xpath->evaluate('string(/' . trim($match, '{}') . ')');
+                }
+
+                // Insert a '/' if the expression contains a '(' directly followed by the root node name
+                // Fixes expression 1.J (when used inside an xpath-function)
+                else if (strpos($match,'('.$root_node_name) !== false) {
+                    $search = '(';
+                    $index = strpos($match, $search);
+                    $string = substr_replace($match, $search.'/', $index, 1);
+                    $result = @$xpath->evaluate('string('. trim($string, '{}') . ')');
+                }
+
+                // Add the name of the root node if the expression only consist of '/'
+                // Fixes expression 2.A
+                else if ($match === '{/}') {
+                    $result = @$xpath->evaluate('string(/'. $root_node_name . ')');
+                }
+
+                // Use the given expression without modifications
+                else {
+                    $result = @$xpath->evaluate('string(' . trim($match, '{}') . ')');
+                }
 
                 if (!empty($result)) {
                     $replacements[$match] = trim($result);

--- a/fields/field.reflection.php
+++ b/fields/field.reflection.php
@@ -386,7 +386,7 @@
             preg_match_all('/\{[^\}]+\}/', $expression, $matches);
 
             // Get root node name (will be 'data' if not otherwise defined in a xslt utility)
-            $root_node_name = preg_quote ((string)$xpath->evaluate('name(/*)'), '#');
+            $root_node_name = (string)$xpath->evaluate('name(/*)');
 
             // Prepare the root node name for preg_* calls
             $root_node_name_quoted = preg_quote ($root_node_name, '#');

--- a/fields/field.reflection.php
+++ b/fields/field.reflection.php
@@ -386,7 +386,7 @@
             preg_match_all('/\{[^\}]+\}/', $expression, $matches);
 
             // Get root node name
-            $root_node_name = $xpath->evaluate('name(/*)');
+            $root_node_name = preg_quote ((string)$xpath->evaluate('name(/*)'), '#');
 
             // Find replacements
             // including modifications for edge-cases (#35)
@@ -407,7 +407,7 @@
                     $result = @$xpath->evaluate('string('. trim($string, '{}') . ')');
                 }
 
-                // Add the name of the root node if the expression only consist of '/'
+                // Add the name of the root node if the expression only consists of '/'
                 // Fixes expression 2.A
                 else if ($match === '{/}') {
                     $result = @$xpath->evaluate('string(/'. $root_node_name . ')');

--- a/fields/field.reflection.php
+++ b/fields/field.reflection.php
@@ -385,8 +385,11 @@
             // Find queries:
             preg_match_all('/\{[^\}]+\}/', $expression, $matches);
 
-            // Get root node name
+            // Get root node name (will be 'data' if not otherwise defined in a xslt utility)
             $root_node_name = preg_quote ((string)$xpath->evaluate('name(/*)'), '#');
+
+            // Prepare the root node name for preg_* calls
+            $root_node_name_quoted = preg_quote ($root_node_name, '#');
 
             // Find replacements
             // including modifications for edge-cases (#35)
@@ -394,7 +397,7 @@
 
                 // Add a leading '/' if the expression starts with the root node name
                 // Fixes expressions 1.J and 2.B
-                if (preg_match('#^{'.$root_node_name.'#', $match)) {
+                if (preg_match('#^{'.$root_node_name_quoted.'#', $match)) {
                     $result = @$xpath->evaluate('string(/' . trim($match, '{}') . ')');
                 }
 


### PR DESCRIPTION
This change aims to implement support for **all** valid xpath-expressions inside the „expression“-field.

See https://github.com/symphonists/reflectionfield/issues/35 for details.